### PR TITLE
optional imagemagick/convert full path

### DIFF
--- a/image_pipeline.py
+++ b/image_pipeline.py
@@ -52,10 +52,10 @@ parser.add_argument('-s', '--surveys', default=None, nargs='*', type=str,
                          ' contours. DSS2 Blue is always made by default. These additional non-SkyView options are\n'
                          ' available: \'panstarrs\',\'hst\'.  \'hst\' only refers to COSMOS HST (e.g. for CHILES).')
 
-parser.add_argument('-m', '--imagemagick', default=False,
-                    help='If imagemagick is installed on user\'s system, optionally combine main plots into single '
-                         'large file',
-                    action='store_true')
+parser.add_argument('-m', '--imagemagick', nargs='?', type=str, default='', const='convert',
+                    help='Optionally combine the main plots into single large image file using the IMAGEMAGICK CONVERT task.'
+                         ' If this option is given with no argument we simply assume that CONVERT is executed by the "convert"'
+                         ' command. Otherwise, the argument of this option gives the full path to the CONVERT executable.')
 
 ###################################################################
 
@@ -64,6 +64,7 @@ args = parser.parse_args()
 suffix = args.suffix
 original = args.original
 imagemagick = args.imagemagick
+
 try:
     beam = [int(b) for b in args.beam.split(',')]
 except:
@@ -172,7 +173,7 @@ for source in catalog:
     make_spectra.main(source, src_basename, original, suffix=suffix, beam=beam)
 
     if imagemagick:
-        combine_images(source, src_basename, suffix=suffix)
+        combine_images(source, src_basename, imagemagick, suffix=suffix)
 
     n_src += 1
 

--- a/src/combine_images.py
+++ b/src/combine_images.py
@@ -2,11 +2,7 @@ import os
 
 
 # Note, although this has been generalized, it seems to work best with png's!
-def combine_images(source, src_basename, suffix='png'):
-
-    # Specify the command to use imagemagick's convert (karma has a convert which may conflict)
-    # convert_im = "/usr/local/Cellar/imagemagick/7.1.0-13/bin/convert"
-    convert_im = "convert"
+def combine_images(source, src_basename, imgck, suffix='png'):
 
     # Configure expected file name:
     infile = src_basename.replace('cubelets', 'figures') + '_{}_'.format(source['id'])
@@ -15,11 +11,11 @@ def combine_images(source, src_basename, suffix='png'):
     print("\n\tAssembling figures with imagemagck for source {}: {}.".format(source['id'], source['name']))
     new_file = "{}combo.{}".format(infile, suffix)
     os.system("{0} {1}mom0dss2blue.{2} {1}mom0hi.{2} {1}snr.{2} {1}mom1.{2}"
-              " +append temp.{2}".format(convert_im, infile, suffix))
-    os.system("{0} {1}spec.{2} -resize 125% temp2.{2}".format(convert_im, infile, suffix))
-    os.system("{0} {1}specfull.{2} -resize 125% temp3.{2}".format(convert_im, infile, suffix))
-    os.system("{0} temp2.{2} temp3.{2} {1}pv.{2} +append temp4.{2}".format(convert_im, infile, suffix))
-    os.system("{0} temp.{2} temp4.{2} -append {1}".format(convert_im, new_file, suffix))
+              " +append temp.{2}".format(imgck, infile, suffix))
+    os.system("{0} {1}spec.{2} -resize 125% temp2.{2}".format(imgck, infile, suffix))
+    os.system("{0} {1}specfull.{2} -resize 125% temp3.{2}".format(imgck, infile, suffix))
+    os.system("{0} temp2.{2} temp3.{2} {1}pv.{2} +append temp4.{2}".format(imgck, infile, suffix))
+    os.system("{0} temp.{2} temp4.{2} -append {1}".format(imgck, new_file, suffix))
     os.system('rm -rf temp*.{}'.format(suffix))
 
     return


### PR DESCRIPTION
This PR implements the following behaviour:

- `python image_pipeline.py` -> NO per-source atlas image made with CONVERT
- `python image_pipeline.py -m` -> per-source atlas image made with CONVERT assuming it is executed by the `convert` command
- `python image_pipeline.py -m blabla` -> per-source atlas image made with CONVERT assuming the full path to the CONVERT executable is `blabla`

See #11 