### PR TITLE
do not regrid HI images & detect single-channel sources

### DIFF
--- a/src/make_images.py
+++ b/src/make_images.py
@@ -30,6 +30,7 @@ optical_HI = u.doppler_optical(HI_restfreq)
 
 # Overlay HI contours on user image
 
+
 def make_overlay_usr(source, src_basename, cube_params, patch, opt, base_contour, swapx, perc, suffix='png'):
     """Overlay HI contours on top of a user provided image
 
@@ -689,6 +690,7 @@ def main(source, src_basename, opt_view=6*u.arcmin, suffix='png', sofia=2, beam=
 
     # For CHILES: plot HI contours on HST image if desired.
     if ('hst' in surveys) | ('HST' in surveys):
+        swapx = False
         hst_opt_view = 40 * u.arcsec
         if np.any(Xsize > hst_opt_view.to(u.arcmin).value / 2) | np.any(Ysize > hst_opt_view.to(u.arcmin).value / 2):
             hst_opt_view = (np.max([Xsize, Ysize]) * 2 * 1.05 * u.arcmin).to(u.arcsec)
@@ -697,7 +699,7 @@ def main(source, src_basename, opt_view=6*u.arcmin, suffix='png', sofia=2, beam=
             patch_height = (cube_params['bmaj'] / hst_opt_view).decompose()
             patch_width = (cube_params['bmin'] / hst_opt_view).decompose()
             patch_hst = {'width': patch_width, 'height': patch_height}
-            make_overlay(source, src_basename, cube_params, patch_hst, hst_opt, HIlowest, suffix=suffix,
+            make_overlay(source, src_basename, cube_params, patch_hst, hst_opt, HIlowest, swapx, suffix=suffix,
                          survey='hst')
         if surveys[0] == 'hst':
             opt_head = hst_opt[0].header
@@ -736,7 +738,7 @@ def main(source, src_basename, opt_view=6*u.arcmin, suffix='png', sofia=2, beam=
         for survey in surveys:
             try:
                 overlay_image = get_skyview(hi_pos_common, opt_view=opt_view, survey=survey)
-                make_overlay(source, src_basename, cube_params, patch, overlay_image, HIlowest, suffix=suffix,
+                make_overlay(source, src_basename, cube_params, patch, overlay_image, HIlowest, swapx, suffix=suffix,
                              survey=survey)
                 if surveys[0] == survey:
                     opt_head = overlay_image[0].header
@@ -749,7 +751,7 @@ def main(source, src_basename, opt_view=6*u.arcmin, suffix='png', sofia=2, beam=
                       " cache=False.".format(survey))
                 try:
                     overlay_image = get_skyview(hi_pos_common, opt_view=opt_view, survey=survey, cache=False)
-                    make_overlay(source, src_basename, cube_params, patch, overlay_image, HIlowest, suffix=suffix,
+                    make_overlay(source, src_basename, cube_params, patch, overlay_image, HIlowest, swapx, suffix=suffix,
                                  survey=survey)
                     if surveys[0] == survey:
                         opt_head = overlay_image[0].header
@@ -760,7 +762,7 @@ def main(source, src_basename, opt_view=6*u.arcmin, suffix='png', sofia=2, beam=
                       " cache=False.".format(survey))
                 try:
                     overlay_image = get_skyview(hi_pos_common, opt_view=opt_view, survey=survey, cache=False)
-                    make_overlay(source, src_basename, cube_params, patch, overlay_image, HIlowest, suffix=suffix,
+                    make_overlay(source, src_basename, cube_params, patch, overlay_image, HIlowest, swapx, suffix=suffix,
                                  survey=survey)
                     if surveys[0] == survey:
                         opt_head = overlay_image[0].header

--- a/src/make_images.py
+++ b/src/make_images.py
@@ -353,6 +353,11 @@ def make_mom1(source, hi_pos_common, src_basename, cube_params, patch, opt_head,
             if cube_params['spec_axis'] == 'VRAD':
                 convention = 'Radio'
 
+        if velmin == velmax:
+            singlechansource = True
+        else:
+            singlechansource = False
+
         mom1_cut = Cutout2D(mom1[0].data, hi_pos_common, [opt_view.to(u.deg).value/np.abs(mom1[0].header['cdelt1']), opt_view.to(u.deg).value/np.abs(mom1[0].header['cdelt2'])], wcs=WCS(mom1[0].header), mode='partial')
         # Only plot values above the lowest calculated HI value:
         hdulist_hi = fits.open(src_basename + '_{}_mom0.fits'.format(str(source['id'])))
@@ -365,7 +370,11 @@ def make_mom1(source, hi_pos_common, src_basename, cube_params, patch, opt_head,
         fig = plt.figure(figsize=(8, 8))
         ax1 = fig.add_subplot(111, projection=hi_cut.wcs)
         plot_labels(source, ax1)
-        im = ax1.imshow(mom1_cut.data, cmap='RdBu_r', origin='lower')
+        if not singlechansource:
+            im = ax1.imshow(mom1_cut.data, cmap='RdBu_r', origin='lower')
+        else:
+            im = ax1.imshow(mom1_cut.data, cmap='RdBu_r', origin='lower',
+                 vmin=0.999*np.nanmin(mom1_cut.data), vmax=1.001*np.nanmax(mom1_cut.data))
         vel_maxhalf = np.max([np.abs(velmax-v_sys), np.abs(v_sys-velmin)])
         for vunit in [5, 10, 20, 25, 30, 40, 50, 60, 75, 100, 125, 150]:
             n_contours = vel_maxhalf // vunit
@@ -373,7 +382,8 @@ def make_mom1(source, hi_pos_common, src_basename, cube_params, patch, opt_head,
                 break
         levels = [v_sys-3*vunit, v_sys-2*vunit, v_sys-1*vunit, v_sys, v_sys+1*vunit, v_sys+2*vunit, v_sys+3*vunit]
         clevels = ['white', 'lightgray', 'dimgrey', 'black', 'dimgrey', 'lightgray', 'white']
-        cf = ax1.contour(mom1_cut.data, colors=clevels, levels=levels, linewidths=0.6)
+        if not singlechansource:
+            cf = ax1.contour(mom1_cut.data, colors=clevels, levels=levels, linewidths=0.6)
         v_sys_label = "$v_{{sys}}$ = {}  $W_{{50}}$ = {}  $W_{{20}}$ = {} km/s".format(int(v_sys), int(w50), int(w20))
         # Plot kin_pa from HI center of galaxy
         ax1.annotate("", xy=((hi_pos.ra + 0.45 * opt_view[0] * np.sin(kinpa) / np.cos(hi_pos.dec)).deg,
@@ -383,13 +393,15 @@ def make_mom1(source, hi_pos_common, src_basename, cube_params, patch, opt_head,
                      arrowprops=dict(arrowstyle="->,head_length=0.8,head_width=0.4", connectionstyle="arc3",
                                      linestyle='--'))
         ax1.text(0.5, 0.05, v_sys_label, ha='center', va='center', transform=ax1.transAxes, color='black', fontsize=18)
-        ax1.text(0.95, 0.5, "$\Delta v_{{contours}}$ = {} km/s".format(int(vunit)), ha='center', va='center',
-                 transform=ax1.transAxes, color='black', fontsize=18, rotation=90)
+        if not singlechansource:
+            ax1.text(0.95, 0.5, "$\Delta v_{{contours}}$ = {} km/s".format(int(vunit)), ha='center', va='center',
+                     transform=ax1.transAxes, color='black', fontsize=18, rotation=90)
         ax1.add_patch(Ellipse((0.92, 0.9), height=patch['height'], width=patch['width'], angle=cube_params['bpa'],
                               transform=ax1.transAxes, edgecolor='darkred', linewidth=1))
         cb_ax = fig.add_axes([0.91, 0.11, 0.02, 0.76])
         cbar = fig.colorbar(im, cax=cb_ax)
-        cbar.add_lines(cf)
+        if not singlechansource:
+            cbar.add_lines(cf)
         cbar.set_label("{} {} Velocity [km/s]".format(cube_params['spec_sys'].capitalize(), convention), fontsize=18)
 
 #         if swapx:

--- a/src/make_images.py
+++ b/src/make_images.py
@@ -527,7 +527,7 @@ def make_pv(source, src_basename, cube_params, opt_view=6*u.arcmin, suffix='png'
 
         # if np.all (np.isnan (pv[0].data)): continue
         # Plot positive contours
-        if np.nanmin(pvd) > 3*pvd_rms:
+        if np.nanmax(pvd) > 3*pvd_rms:
             ax1.contour(pvd, colors=['k', ], levels=3**np.arange(1, 10)*pvd_rms)
         # Plot negative contours
         if np.nanmin(pvd) < -3*pvd_rms:

--- a/src/make_spectra.py
+++ b/src/make_spectra.py
@@ -237,7 +237,7 @@ def main(source, src_basename, original=None, suffix='png', beam=None):
         fig2.savefig(outfile2, bbox_inches='tight')
     plt.close('all')
 
-    print("\tDone making spectral profiles of the spectral line source {}: {}.".format(source['id'], source['name']))
+    print("\tDone making spectral profiles.")
 
     return
 


### PR DESCRIPTION
close #15 #53

Concerning #15, the main idea discussed in that issue and implemented here is to use `astropy.nddata.Cutout2D` instead of `reproject.reproject_interp`. I've noticed that there are very small differences in the RA,Dec axes layout between the two approaches, but I think they can be neglected.

Concerning #53, the changes for single-channel sources are:
- do not plot the meaningless mom1 contours to prevent the code from crashing
- adjust `vmin` and `vmax` of the `imshow()` command to avoid having a weird colorbar

This PR also includes some changes to improve the plotting of negative HI contours, as discussed in #43.

I've also made a few minor (and unrelated) changes, e.g., in the PVD log messages and other log messages.