### PR TITLE
Usr color

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ OPTIONAL:
     -snr   Specify the SNR range within which to plot the lowest HI contour. Requires 2 values. Default is [2.0, 3.0].
     -s     List of surveys on which to overlay HI contours. Only the first entry will be used in the combined image if `-m` option is used. Default is 'DSS2 Blue'.
     -m     Make a combined image using ImageMagick.  If a path is provided after this option, it is assumed to be the path to the `convert` executable of ImageMagick. 
-    -ui    User supplied image for overlaying HI contours.  Can use this in combination with `-s` and a list of surveys.
+    -ui    User supplied image fits or jpg/png color image for overlaying HI contours.  Can use this in combination with `-s` and a list of surveys.
     -ur    Percentile range when plotting the user supplied image.  Requires two values. Default is [10., 99.].
 ```
 
@@ -166,7 +166,6 @@ See the github repo for known bugs and desired enhancements.  We aim to fix seri
 
 In addition we are aware of the following issues:
 * Saving figures with .ps or .eps format has issues with transparency and background colors appearing black.
-* `download_usr_fig` can download full color images from PanSTARRS and DECaLS, but these can not yet be read as user supplied input to `sofia_image_pipeline`.
 * WISE images, PanSTARRS and DECaLS cannot (yet) be plotted with Galactic coordinates.
 * The mask (red line) on pv-diagram plots may not be perfectly aligned from left-to-right.  Please use this line only as a rough indication of the mask position.  Refer to actual data for the truth.  Any suggestions for how to improve this are welcome.
 * For data with channels that are not uniform in width (e.g. `SPECSYS = FELO-OPT`), SIP's conversion to km/s is off compared to SoFiA-2's: the programs use formula from [here](https://www.astro.rug.nl/software/kapteyn/spectralbackground.html#aips-axis-type-felo) or use wcslib to do the conversion, respectively.  We haven't tracked down the discrepancy.  To the best of our knowledge, only relatively old radio data observing nearby galaxies, might be in this `FELO` format. 

--- a/src/image_pipeline.py
+++ b/src/image_pipeline.py
@@ -69,7 +69,8 @@ def main():
                             ' spectral line data.')
 
     parser.add_argument('-ui', '--user-image', default=None,
-                        help='Optional: Full path to the FITS image on which to overlay HI contours.')
+                        help='Optional: Full path to the FITS image on which to overlay HI contours.  Users can also provide\n'
+                             ' a false color jpg or png image, as long as there is a matching fits file that ends in "_hdr.fits".')
 
     parser.add_argument('-ur', '--user-range', default=[10., 99.], nargs=2, type=float,
                         help='Optional: Percentile range used when displaying the user image (see "-ui"). Default is [10,99].')

--- a/src/make_images.py
+++ b/src/make_images.py
@@ -171,6 +171,8 @@ def make_overlay(source, src_basename, cube_params, patch, opt, base_contour, sw
     :type opt: dict
     :param base_contour: base contour
     :type base_contour: float
+    :param swapx: invert the x-axis if cdelt is negative
+    :type swapx: bool
     :param suffix: file type, defaults to 'png'
     :type suffix: str, optional
     :param survey: survey from which to use data, defaults to 'DSS2 Blue'
@@ -241,7 +243,7 @@ def make_overlay(source, src_basename, cube_params, patch, opt, base_contour, sw
 
 
 # Make HI grey scale image
-def make_mom0(source, hi_pos_common, src_basename, cube_params, patch, opt_head, opt_view, base_contour, swapx, suffix='png'):
+def make_mom0(source, src_basename, cube_params, patch, opt_head, base_contour, swapx, suffix='png'):
     """Overlay HI contours on the HI gray scale image.
 
     :param source: source object
@@ -305,12 +307,6 @@ def make_mom0(source, hi_pos_common, src_basename, cube_params, patch, opt_head,
         cbar = fig.colorbar(im, cax=cb_ax)
         cbar.set_label("HI Intensity [{}]".format(hdulist_hi[0].header['bunit']), fontsize=18)
 
-        # owcs = WCS(opt_head)
-        # Wlims = owcs.wcs_pix2world([[0, 0], [opt_head['NAXIS1'], opt_head['NAXIS2']]], 0)
-        # lims = hiwcs.wcs_world2pix(Wlims, 0)
-
-        # ax1.set_ylim(lims[0,1], lims[1,1])
-        # ax1.set_xlim(lims[0,0], lims[1,0])
         ax1.set_xlim(0, opt_head['NAXIS1'])
         ax1.set_ylim(0, opt_head['NAXIS2'])
 
@@ -328,7 +324,7 @@ def make_mom0(source, hi_pos_common, src_basename, cube_params, patch, opt_head,
 
 
 # Make HI significance image
-def make_snr(source, hi_pos_common, src_basename, cube_params, patch, opt_head, opt_view, base_contour, swapx, suffix='png'):
+def make_snr(source, src_basename, cube_params, patch, opt_head, base_contour, swapx, suffix='png'):
     """Plot the pixel-by-pixel signal-to-noise ratio for the total intensity map of the source.
 
     :param source: source object
@@ -394,13 +390,6 @@ def make_snr(source, hi_pos_common, src_basename, cube_params, patch, opt_head, 
         cbar = fig.colorbar(im, cax=cb_ax)
         cbar.set_label("Pixel SNR", fontsize=18)
 
-        # Debugging grid
-        # ax1.grid(True, ls=':', lw=0.8, color='gray')
-        # Wlims = owcs.wcs_pix2world([[0, 0], [opt_head['NAXIS1'], opt_head['NAXIS2']]], 0)
-        # lims = hiwcs.wcs_world2pix(Wlims, 0)
-        # ax1.set_ylim(lims[0,1], lims[1,1])
-        # ax1.set_xlim(lims[0,0], lims[1,0])
-
         ax1.set_xlim(0, opt_head['NAXIS1'])
         ax1.set_ylim(0, opt_head['NAXIS2'])
 
@@ -414,7 +403,7 @@ def make_snr(source, hi_pos_common, src_basename, cube_params, patch, opt_head, 
 
 
 # Make velocity map for object
-def make_mom1(source, hi_pos_common, src_basename, cube_params, patch, opt_head, opt_view, base_contour, swapx, suffix='png', sofia=2):
+def make_mom1(source, src_basename, cube_params, patch, opt_head, opt_view, base_contour, swapx, suffix='png', sofia=2):
     """
 
     :param source: source object
@@ -563,20 +552,9 @@ def make_mom1(source, hi_pos_common, src_basename, cube_params, patch, opt_head,
             cbar.add_lines(cf)
         cbar.set_label("{} {} Velocity [km/s]".format(cube_params['spec_sys'].capitalize(), convention), fontsize=18)
 
-        # Debugging grid
-        # ax1.grid(True, ls=':', lw=0.8, color='gray')
-
-        # Wlims = owcs.wcs_pix2world([[0, 0], [opt_head['NAXIS1'], opt_head['NAXIS2']]], 0)
-        # lims = hiwcs.wcs_world2pix(Wlims, 0)
-        # ax1.set_ylim(lims[0,1], lims[1,1])
-        # ax1.set_xlim(lims[0,0], lims[1,0])
-
         ax1.set_xlim(0, opt_head['NAXIS1'])
         ax1.set_ylim(0, opt_head['NAXIS2'])
 
-
-#         if swapx:
-#             ax1.set_xlim(ax1.get_xlim()[::-1])
         fig.savefig(outfile, bbox_inches='tight')
 
         mom1.close()
@@ -649,11 +627,6 @@ def make_color_im(source, src_basename, cube_params, patch, color_im, opt_head, 
                  color='white', fontsize=18)
         ax1.add_patch(Ellipse((0.92, 0.9), height=patch['height'], width=patch['width'], angle=cube_params['bpa'],
                               transform=ax1.transAxes, edgecolor='lightgray', linewidth=1))
-
-        # Wlims = owcs.wcs_pix2world([[0, 0], [opt_head['NAXIS1'], opt_head['NAXIS2']]], 0)
-        # lims = hiwcs.wcs_world2pix(Wlims, 0)
-        # ax1.set_ylim(lims[0,1], lims[1,1])
-        # ax1.set_xlim(lims[0,0], lims[1,0])
 
         ax1.set_xlim(0, opt_head['NAXIS1'])
         ax1.set_ylim(0, opt_head['NAXIS2'])
@@ -1006,11 +979,11 @@ def main(source, src_basename, opt_view=6*u.arcmin, suffix='png', sofia=2, beam=
 
     # Make the rest of the images if there is a survey image to regrid to.
     if opt_head:
-        make_mom0(source, hi_pos_common, src_basename, cube_params, patch, opt_head, opt_view, HIlowest, swapx, suffix=suffix)
-        make_snr(source,  hi_pos_common, src_basename, cube_params, patch, opt_head, opt_view, HIlowest, swapx, suffix=suffix)
-        make_mom1(source, hi_pos_common, src_basename, cube_params, patch, opt_head, opt_view, HIlowest, swapx, suffix=suffix, sofia=2)
+        make_mom0(source, src_basename, cube_params, patch, opt_head, opt_view, HIlowest, swapx, suffix=suffix)
+        make_snr(source, src_basename, cube_params, patch, opt_head, opt_view, HIlowest, swapx, suffix=suffix)
+        make_mom1(source, src_basename, cube_params, patch, opt_head, opt_view, HIlowest, swapx, suffix=suffix, sofia=2)
 
-    # Make pv if it was created (only in SoFiA-1); not dependent on having a survey image to regrid to.
+    # Make pv if it was created; not dependent on having a survey image to regrid to.
     make_pv(source, src_basename, cube_params, opt_view=opt_view, suffix=suffix)
 
     plt.close('all')

--- a/src/make_images.py
+++ b/src/make_images.py
@@ -242,7 +242,7 @@ def make_overlay(source, src_basename, cube_params, patch, opt, base_contour, sw
 
 
 # Make HI grey scale image
-def make_mom0(source, src_basename, cube_params, patch, opt_head, base_contour, swapx, suffix='png'):
+def make_mom0(source, src_basename, cube_params, patch, opt_head, base_contour, suffix='png'):
     """Overlay HI contours on the HI gray scale image.
 
     :param source: source object
@@ -309,8 +309,6 @@ def make_mom0(source, src_basename, cube_params, patch, opt_head, base_contour, 
         ax1.set_xlim(0, opt_head['NAXIS1'])
         ax1.set_ylim(0, opt_head['NAXIS2'])
 
-        # if swapx:
-        #     ax1.set_xlim(ax1.get_xlim()[::-1])
         fig.savefig(outfile, bbox_inches='tight')
 
         hdulist_hi.close()
@@ -322,7 +320,7 @@ def make_mom0(source, src_basename, cube_params, patch, opt_head, base_contour, 
 
 
 # Make HI significance image
-def make_snr(source, src_basename, cube_params, patch, opt_head, base_contour, swapx, suffix='png'):
+def make_snr(source, src_basename, cube_params, patch, opt_head, base_contour, suffix='png'):
     """Plot the pixel-by-pixel signal-to-noise ratio for the total intensity map of the source.
 
     :param source: source object
@@ -401,7 +399,7 @@ def make_snr(source, src_basename, cube_params, patch, opt_head, base_contour, s
 
 
 # Make velocity map for object
-def make_mom1(source, src_basename, cube_params, patch, opt_head, opt_view, base_contour, swapx, suffix='png', sofia=2):
+def make_mom1(source, src_basename, cube_params, patch, opt_head, opt_view, base_contour, suffix='png', sofia=2):
     """
 
     :param source: source object
@@ -856,7 +854,7 @@ def main(source, src_basename, opt_view=6*u.arcmin, suffix='png', sofia=2, beam=
             print("\tCould not determine pixel size of user image. Aborting.")
             exit()
 
-        if (usrim_pix_x > 0.0):
+        if usrim_pix_x > 0.0:
             swapx = True
         else:
             swapx = False
@@ -981,9 +979,9 @@ def main(source, src_basename, opt_view=6*u.arcmin, suffix='png', sofia=2, beam=
 
     # Make the rest of the images if there is a survey image to regrid to.
     if opt_head:
-        make_mom0(source, src_basename, cube_params, patch, opt_head, HIlowest, swapx, suffix=suffix)
-        make_snr(source, src_basename, cube_params, patch, opt_head, HIlowest, swapx, suffix=suffix)
-        make_mom1(source, src_basename, cube_params, patch, opt_head, opt_view, HIlowest, swapx, suffix=suffix, sofia=2)
+        make_mom0(source, src_basename, cube_params, patch, opt_head, HIlowest, suffix=suffix)
+        make_snr(source, src_basename, cube_params, patch, opt_head, HIlowest, suffix=suffix)
+        make_mom1(source, src_basename, cube_params, patch, opt_head, opt_view, HIlowest, suffix=suffix, sofia=2)
 
     # Make pv if it was created; not dependent on having a survey image to regrid to.
     make_pv(source, src_basename, cube_params, opt_view=opt_view, suffix=suffix)

--- a/src/make_images.py
+++ b/src/make_images.py
@@ -229,7 +229,6 @@ def make_overlay(source, src_basename, cube_params, patch, opt, base_contour, sw
         ax1.add_patch(Ellipse((0.92, 0.9), height=patch['height'], width=patch['width'], angle=cube_params['bpa'],
                               transform=ax1.transAxes, edgecolor='white', linewidth=1))
 
-
         if swapx:
             ax1.set_xlim(ax1.get_xlim()[::-1])
         fig.savefig(outfile, bbox_inches='tight')
@@ -310,8 +309,8 @@ def make_mom0(source, src_basename, cube_params, patch, opt_head, base_contour, 
         ax1.set_xlim(0, opt_head['NAXIS1'])
         ax1.set_ylim(0, opt_head['NAXIS2'])
 
-        if swapx:
-            ax1.set_xlim(ax1.get_xlim()[::-1])
+        # if swapx:
+        #     ax1.set_xlim(ax1.get_xlim()[::-1])
         fig.savefig(outfile, bbox_inches='tight')
 
         hdulist_hi.close()
@@ -857,7 +856,7 @@ def main(source, src_basename, opt_view=6*u.arcmin, suffix='png', sofia=2, beam=
             print("\tCould not determine pixel size of user image. Aborting.")
             exit()
 
-        if (usrim_pix_x > 0) & (not color_im):
+        if (usrim_pix_x > 0.0):
             swapx = True
         else:
             swapx = False
@@ -880,8 +879,8 @@ def main(source, src_basename, opt_view=6*u.arcmin, suffix='png', sofia=2, beam=
                                                     Image.fromarray(usrim_cut_b.data)))
                 usrim_cut.data = usrim_cut_rgb
             else:
-                usrim_cut = Cutout2D(usrim_d, hi_pos, [opt_view.to(u.deg).value/usrim_pix_y, opt_view.to(u.deg).value/usrim_pix_x], wcs=usrim_wcs, mode='partial')
-
+                usrim_cut = Cutout2D(usrim_d, hi_pos, [opt_view.to(u.deg).value/usrim_pix_y, opt_view.to(u.deg).value/usrim_pix_x],
+                                     wcs=usrim_wcs, mode='partial')
             make_overlay_usr(source, src_basename, cube_params, patch, usrim_cut, HIlowest, swapx, user_range, suffix='png', color_im=color_im)
             opt_head = usrim_cut.wcs.to_header()
             # wcs.to_header() seems to have a bug where it doesn't include the axis information.
@@ -982,8 +981,8 @@ def main(source, src_basename, opt_view=6*u.arcmin, suffix='png', sofia=2, beam=
 
     # Make the rest of the images if there is a survey image to regrid to.
     if opt_head:
-        make_mom0(source, src_basename, cube_params, patch, opt_head, opt_view, HIlowest, swapx, suffix=suffix)
-        make_snr(source, src_basename, cube_params, patch, opt_head, opt_view, HIlowest, swapx, suffix=suffix)
+        make_mom0(source, src_basename, cube_params, patch, opt_head, HIlowest, swapx, suffix=suffix)
+        make_snr(source, src_basename, cube_params, patch, opt_head, HIlowest, swapx, suffix=suffix)
         make_mom1(source, src_basename, cube_params, patch, opt_head, opt_view, HIlowest, swapx, suffix=suffix, sofia=2)
 
     # Make pv if it was created; not dependent on having a survey image to regrid to.


### PR DESCRIPTION
I'm trying to take downloaded color images in jpg or png which supposedly have matching pixels with a similarly downloaded fits image for the header and plot HI contours, etc in make_overlay_usr().  Unfortunately it only works for the galaxy at the center of the image, and not for others.  I think it's either that opening the jpg/png with Image() gives a different order of row/column compared to fits.open(); or that the WCS or Cutout2D is not treating the rotation keywords properly (PC[1,2]_[1,2]).