### PR TITLE
800kB combo png limit + decals-dev

### DIFF
--- a/src/combine_images.py
+++ b/src/combine_images.py
@@ -5,7 +5,7 @@ import string
 
 # Note, although this has been generalized, it seems to work best with png's!
 
-def combine_images(source, src_basename, imgck, suffix='png', surveys='DSS2 Blue', user_image=None):
+def combine_images(source, src_basename, imgck, suffix='png', surveys='DSS2 Blue', user_image=None, file_size_limit = 8e+5):
     """_summary_
 
     :param source: source for which to combine images
@@ -31,7 +31,7 @@ def combine_images(source, src_basename, imgck, suffix='png', surveys='DSS2 Blue
                   " +append temp{3}.{2}".format(imgck, infile, suffix, code))
     elif surveys:
         os.system("{0} {1}mom0_{3}.{2} {1}mom0.{2} {1}snr.{2} {1}mom1.{2}"
-                  " +append temp{4}.{2}".format(imgck, infile, suffix, surveys[0].replace(" ", "").lower(), code))
+                  " +append temp{4}.{2}".format(imgck, infile, suffix, surveys[0].replace(" ", "").lower().replace('decals-dev', 'decals'), code))
     else:
         print("\tWARNING: No ancillary data image available for source {}.".format(source['id']))
         os.system("{0} {1}mom0.{2} {1}snr.{2} {1}mom1.{2} +append temp{3}.{2}".format(imgck, infile, suffix, code))
@@ -39,6 +39,10 @@ def combine_images(source, src_basename, imgck, suffix='png', surveys='DSS2 Blue
     os.system("{0} {1}specfull.{2} -resize 125% temp3{3}.{2}".format(imgck, infile, suffix, code))
     os.system("{0} temp2{3}.{2} temp3{3}.{2} {1}pv.{2} +append temp4{3}.{2}".format(imgck, infile, suffix, code))
     os.system("{0} temp{3}.{2} temp4{3}.{2} -append {1}".format(imgck, new_file, suffix, code))
+    new_file_size = os.path.getsize(new_file)
+    if new_file_size > file_size_limit:
+        print('\tReducing size of combined image to {0:.0f}% of original (it was {1:.1e}B)'.format(100*file_size_limit/new_file_size, new_file_size))
+        os.system("{0} {1} -resize {2:.0f}% {1}".format(imgck, new_file, 100*file_size_limit/new_file_size))
     os.system('rm -rf temp*{1}.{0}'.format(suffix, code))
 
     return

--- a/src/make_images.py
+++ b/src/make_images.py
@@ -88,7 +88,7 @@ def make_overlay_usr(source, src_basename, cube_params, patch, opt, base_contour
         except FileNotFoundError:
             print("\tNo mom0 fits file. Perhaps you ran SoFiA without generating moments?")
             return
-        
+
         nhi, nhi_label, nhi_labels = sbr2nhi(base_contour, hdulist_hi[0].header['bunit'], cube_params['bmaj'].value,
                                              cube_params['bmin'].value)
 
@@ -881,8 +881,15 @@ def main(source, src_basename, opt_view=6*u.arcmin, suffix='png', sofia=2, beam=
         surveys.remove('panstarrs')
 
     # If requested plot HI contours on DECaLS imaging
+    dev_dr = False
+    if 'decals' in surveys and 'decals-dev' in surveys:
+        print("\tERROR: Only one between decals and decals-dev can be given.")
+        exit()
+    elif 'decals-dev' in surveys:
+        surveys[surveys.index('decals-dev')] = 'decals'
+        dev_dr = True
     if ('decals' in surveys) and (hi_pos_common.frame.name != 'galactic'):
-        decals_im, decals_head = get_decals(hi_pos_common, opt_view=opt_view)
+        decals_im, decals_head = get_decals(hi_pos_common, opt_view=opt_view, dev_dr=dev_dr)
         make_color_im(source, src_basename, cube_params, patch, decals_im, decals_head, HIlowest, suffix=suffix,
                       survey='decals')
         if surveys[0] == 'decals':

--- a/src/modules/get_ancillary.py
+++ b/src/modules/get_ancillary.py
@@ -82,7 +82,7 @@ def get_panstarrs(hi_pos, opt_view=6*u.arcmin):
     return color_im, fits_head
 
 
-def get_decals(hi_pos, opt_view=6*u.arcmin):
+def get_decals(hi_pos, opt_view=6*u.arcmin, dev_dr=False):
     """Get DECaLS false color image and g-band fits (for the WCS).
 
     :param hi_pos: position in the HI data
@@ -95,8 +95,12 @@ def get_decals(hi_pos, opt_view=6*u.arcmin):
     # Get DECaLS false color image and fits (for the WCS). Example URL for this script provided by John Wu.
     pixscale = 0.262   # default(?) arcsec/pixel
     dimen = (opt_view.to(u.arcsec).value / pixscale).astype(int)
-    url = 'https://www.legacysurvey.org/viewer/cutout.fits?ra={}&dec={}&layer=ls-dr9&' \
-          'pixscale={}&width={}&height={}&bands=g'.format(hi_pos.ra.deg, hi_pos.dec.deg, pixscale, dimen[0], dimen[-1])
+    if dev_dr:
+        url = 'https://www.legacysurvey.org/viewer-dev/cutout.fits?ra={}&dec={}&layer=ls-dr10-grz&' \
+              'pixscale={}&width={}&height={}&bands=g'.format(hi_pos.ra.deg, hi_pos.dec.deg, pixscale, dimen[0], dimen[-1])
+    else:
+        url = 'https://www.legacysurvey.org/viewer/cutout.fits?ra={}&dec={}&layer=ls-dr9&' \
+              'pixscale={}&width={}&height={}&bands=g'.format(hi_pos.ra.deg, hi_pos.dec.deg, pixscale, dimen[0], dimen[-1])
 
     try:
         fits_head = fits.getheader(url)


### PR DESCRIPTION
This PR:

- Introduces a hardcoded upper limit on the size of the combo image (800kB)
- Allows users to select `decals-dev` instead of `decals`, which currently gives them access to preliminary DECaLS DR10 images. These seem as deep as DR9, maybe less refined, but cover a lot more sky.