### PR TITLE
Improve dependencies, new python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ SIP takes a SoFiA generated source catalog and produce images for publication or
 
 Requirements
 ------------
-This code has been developed and tested with Python 3.9.7, and appears to work with up to Python 3.11, but not 3.12.
+This code has been developed and tested with Python 3.9.7, and appears to work with up to Python 3.12.
 
 Combining individual images with the `-m` option requires [ImageMagick](https://imagemagick.org) be installed.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,14 @@ classifiers = [
 dependencies = [
     "astropy >= 5.0.2",
     "astroquery >= 0.4.7",
-    "matplotlib >= 3.5.1, <3.8",
-    "numpy == 1.22.0",
+    "matplotlib >= 3.5.1",
+    "numpy >= 1.22.0",
     "Pillow >= 10.0.1",
     "pvextractor >= 0.4",
     "requests >= 2.31.0",
     "setuptools >= 65.5.1",
-    "sphinx_rtd_theme == 1.0.0",
-    "xmltodict == 0.12.0",
+    "sphinx_rtd_theme >= 1.0.0",
+    "xmltodict >= 0.12.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 astropy>=5.0.2
 astroquery>=0.4.7
-matplotlib>=3.5.1, <3.8
-numpy==1.22.0
+matplotlib>=3.5.1
+numpy>=1.22.0
 Pillow>=10.0.1
 pvextractor>=0.4
 requests>=2.31.0
 setuptools>=65.5.1
-sphinx_rtd_theme==1.0.0
-xmltodict==0.12.0
+sphinx_rtd_theme>=1.0.0
+xmltodict>=0.12.0

--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ setup(
     install_requires=[
         "astropy >= 5.0.2",
         "astroquery >= 0.4.7",
-        "matplotlib >= 3.5.1, <3.8",
-        "numpy == 1.22.0",
+        "matplotlib >= 3.5.1",
+        "numpy >= 1.22.0",
         "Pillow >= 10.0.1",
         "pvextractor >= 0.4",
         "requests >= 2.31.0",
         "setuptools >= 65.5.1",
-        "sphinx_rtd_theme == 1.0.0",
-        "xmltodict == 0.12.0"
+        "sphinx_rtd_theme >= 1.0.0",
+        "xmltodict >= 0.12.0"
     ],
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
I have removed the upper limits on the dependencies, and now I can also install SIP with python3.12.
I have tested this with python 3.9, 3.10, 3.11, and 3.12 in the following manner:

```bash
mkdir test_py_3x
cd test_py_3x
python3.x -m venv .venv
source .venv/bin/activate
python -m pip install ../SoFiA-image-pipeline-1
sofia_image_pipeline -h
```

In all cases, this resulted in a display of the help message.

However, I have not tested if the functionality carries over correctly to these new versions!
I do not have the expertise and data to correctly assess that.